### PR TITLE
Set pistol animator idle as default

### DIFF
--- a/Assets/Game/Weapons/Pistol/PistolAnimator_origin.controller
+++ b/Assets/Game/Weapons/Pistol/PistolAnimator_origin.controller
@@ -83,7 +83,7 @@ AnimatorStateTransition:
   m_Name: 
   m_Conditions: []
   m_DstStateMachine: {fileID: 0}
-  m_DstState: {fileID: 1047954534556316246}
+  m_DstState: {fileID: 1102730640161936186}
   m_Solo: 0
   m_Mute: 0
   m_IsExit: 0
@@ -666,35 +666,6 @@ AnimatorStateTransition:
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
---- !u!1102 &1047954534556316246
-AnimatorState:
-  serializedVersion: 6
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: New State
-  m_Speed: 1
-  m_CycleOffset: 0
-  m_Transitions:
-  - {fileID: -6884713356173935699}
-  - {fileID: -869096798333539447}
-  - {fileID: 2121942923416092952}
-  m_StateMachineBehaviours: []
-  m_Position: {x: 50, y: 50, z: 0}
-  m_IKOnFeet: 0
-  m_WriteDefaultValues: 1
-  m_Mirror: 0
-  m_SpeedParameterActive: 0
-  m_MirrorParameterActive: 0
-  m_CycleOffsetParameterActive: 0
-  m_TimeParameterActive: 0
-  m_Motion: {fileID: 0}
-  m_Tag: 
-  m_SpeedParameter: 
-  m_MirrorParameter: 
-  m_CycleOffsetParameter: 
-  m_TimeParameter: 
 --- !u!1101 &1101039371219790666
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
@@ -1489,7 +1460,6 @@ AnimatorState:
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
---- !u!1102 &1102730640161936186
 AnimatorState:
   serializedVersion: 6
   m_ObjectHideFlags: 1
@@ -1499,7 +1469,10 @@ AnimatorState:
   m_Name: IdleNormal02_HG01_Anim
   m_Speed: 1
   m_CycleOffset: 0
-  m_Transitions: []
+  m_Transitions:
+  - {fileID: -6884713356173935699}
+  - {fileID: -869096798333539447}
+  - {fileID: 2121942923416092952}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -1847,9 +1820,6 @@ AnimatorStateMachine:
   - serializedVersion: 1
     m_State: {fileID: 1102000565538204170}
     m_Position: {x: -540, y: 210, z: 0}
-  - serializedVersion: 1
-    m_State: {fileID: 1047954534556316246}
-    m_Position: {x: -310, y: -50, z: 0}
   m_ChildStateMachines: []
   m_AnyStateTransitions: []
   m_EntryTransitions: []
@@ -1859,7 +1829,7 @@ AnimatorStateMachine:
   m_EntryPosition: {x: -290, y: 20, z: 0}
   m_ExitPosition: {x: -290, y: 400, z: 0}
   m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
-  m_DefaultState: {fileID: 1047954534556316246}
+  m_DefaultState: {fileID: 1102730640161936186}
 --- !u!1101 &2121942923416092952
 AnimatorStateTransition:
   m_ObjectHideFlags: 1


### PR DESCRIPTION
## Summary
- remove the placeholder "New State" from the pistol animator controller
- set IdleNormal02_HG01_Anim as the base layer default state and reroute incoming transitions

## Testing
- not run (Unity editor unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68ccbd819ea883258a762dfea485560b